### PR TITLE
GH-158 & GH-161: Corrected entity update validation and relationship update

### DIFF
--- a/design/crud-api/cmd/server/service.go
+++ b/design/crud-api/cmd/server/service.go
@@ -178,8 +178,6 @@ func (s *Server) UpdateEntity(ctx context.Context, req *pb.UpdateEntityRequest) 
 	updateEntityID := req.Id
 	updateEntity := req.Entity
 
-	log.Printf("[server.UpdateEntity] Updating Entity: %s", updateEntityID)
-
 	// Initialize metadata
 	var metadata map[string]*anypb.Any
 

--- a/design/crud-api/db/repository/neo4j/neo4j_client.go
+++ b/design/crud-api/db/repository/neo4j/neo4j_client.go
@@ -615,6 +615,7 @@ func (r *Neo4jRepository) UpdateGraphEntity(ctx context.Context, id string, upda
 }
 
 func (r *Neo4jRepository) UpdateRelationship(ctx context.Context, relationshipID string, updateData map[string]interface{}) (map[string]interface{}, error) {
+	log.Printf("[neo4j_client.UpdateRelationship] Updating relationship %s with data: %+v", relationshipID, updateData)
 
 	if relationshipID == "" {
 		log.Printf("[neo4j_client.UpdateRelationship] relationship Id cannot be empty")

--- a/design/tests/e2e/basic_crud_tests.py
+++ b/design/tests/e2e/basic_crud_tests.py
@@ -340,6 +340,60 @@ class GraphEntityTests(BasicCRUDTests):
                 print(f"❌ Failed to create relationship for {dept['name']}: {res.status_code} - {res.text}")
                 sys.exit(1)
 
+    def update_relationships(self):
+        """Update HAS_DEPARTMENT relationships to add termination dates."""
+        print("\n🔗 Updating relationships...")
+        
+        # Set a termination date for all relationships
+        termination_date = "2024-12-31T00:00:00Z"
+        
+        for dept in self.DEPARTMENTS:
+            rel_id = f"rel_{dept['id']}"
+            payload = {
+                "id": self.MINISTER_ID,
+                "kind": {},
+                "created": "",
+                "terminated": "",
+                "name": {},
+                "metadata": [],
+                "attributes": [],
+                "relationships": [
+                    {
+                        "key": "HAS_DEPARTMENT",
+                        "value": {
+                            "relatedEntityId": dept["id"],
+                            "startTime": self.START_DATE,
+                            "endTime": termination_date,  # Add termination date
+                            "id": rel_id,
+                            "name": "HAS_DEPARTMENT"
+                        }
+                    }
+                ]
+            }
+            
+            url = f"{self.base_url}/{self.MINISTER_ID}"
+            res = requests.put(url, json=payload)
+
+            if res.status_code in [200]:
+                print(f"✅ Updated relationship between Minister and {dept['name']} with termination date {termination_date}.")
+            else:
+                print(f"❌ Failed to update relationship for {dept['name']}: {res.status_code} - {res.text}")
+                sys.exit(1)
+
+        # Verify the updates
+        print("\n🔍 Verifying relationship updates...")
+        res = requests.get(f"{self.base_url}/{self.MINISTER_ID}")
+        if res.status_code == 200:
+            data = res.json()
+            relationships = data.get("relationships", [])
+            for rel in relationships:
+                if rel.get("name") == "HAS_DEPARTMENT":
+                    assert rel.get("endTime") == termination_date, f"Expected termination date {termination_date}, got {rel.get('endTime')}"
+            print("✅ Successfully verified relationship updates.")
+        else:
+            print(f"❌ Failed to verify relationship updates: {res.status_code} - {res.text}")
+            sys.exit(1)
+
 
 def get_base_url():
     update_host = os.getenv('UPDATE_SERVICE_HOST', 'localhost')
@@ -360,15 +414,15 @@ if __name__ == "__main__":
         metadata_validation_tests.verify_deletion()
         print("\n🟢 Running Metadata Validation Tests... Done")
 
-        # Commenting out Graph Entity Tests to make tests independent
-        # print("\n🟢 Running Graph Entity Tests...")
-        # graph_entity_tests = GraphEntityTests()
-        # graph_entity_tests.create_minister()
-        # graph_entity_tests.read_minister()
-        # graph_entity_tests.create_departments()
-        # graph_entity_tests.read_departments()
-        # graph_entity_tests.create_relationships()
-        # print("\n🟢 Running Graph Entity Tests... Done")
+        print("\n🟢 Running Graph Entity Tests...")
+        graph_entity_tests = GraphEntityTests()
+        graph_entity_tests.create_minister()
+        graph_entity_tests.read_minister()
+        graph_entity_tests.create_departments()
+        graph_entity_tests.read_departments()
+        graph_entity_tests.create_relationships()
+        graph_entity_tests.update_relationships()
+        print("\n🟢 Running Graph Entity Tests... Done")
 
         print("\n🎉 All tests passed successfully!")
     

--- a/design/tests/e2e/basic_crud_tests.py
+++ b/design/tests/e2e/basic_crud_tests.py
@@ -352,20 +352,16 @@ class GraphEntityTests(BasicCRUDTests):
             payload = {
                 "id": self.MINISTER_ID,
                 "kind": {},
-                "created": "",
-                "terminated": "",
                 "name": {},
-                "metadata": [],
-                "attributes": [],
                 "relationships": [
                     {
-                        "key": "HAS_DEPARTMENT",
+                        "key": rel_id,
                         "value": {
-                            "relatedEntityId": dept["id"],
-                            "startTime": self.START_DATE,
-                            "endTime": termination_date,  # Add termination date
+                            "endTime": termination_date,
                             "id": rel_id,
-                            "name": "HAS_DEPARTMENT"
+                            "relatedEntityId": "",
+                            "startTime": "",
+                            "name": ""
                         }
                     }
                 ]


### PR DESCRIPTION
This pr fixes the incorrect validation of graph entity updates to correctly check only for fields that are needed. It also fixes the issue where relationships were not being correctly updated when using the update endpoint in the update api.

Closes #158 and closes #161 