### PR TITLE
GH-165: [QUERY API] No endpoint for retrieving entity by id

### DIFF
--- a/design/contracts/rest/query_api.yaml
+++ b/design/contracts/rest/query_api.yaml
@@ -38,6 +38,9 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: string
+                  description: Optional entity ID to search for
                 kind:
                   type: object
                   properties:

--- a/design/crud-api/cmd/server/service.go
+++ b/design/crud-api/cmd/server/service.go
@@ -241,11 +241,21 @@ func (s *Server) DeleteEntity(ctx context.Context, req *pb.EntityId) (*pb.Empty,
 
 // ReadEntities retrieves a list of entities filtered by base attributes
 func (s *Server) ReadEntities(ctx context.Context, req *pb.ReadEntityRequest) (*pb.EntityList, error) {
-	if req.Entity == nil || req.Entity.Kind == nil || req.Entity.Kind.Major == "" {
-		return nil, fmt.Errorf("Kind.Major is required for filtering entities")
+	if req.Entity == nil {
+		return nil, fmt.Errorf("entity is required for filtering entities")
 	}
 
-	log.Printf("Filtering entities by Kind.Major: %s", req.Entity.Kind.Major)
+	// Check if we have either an ID or Kind.Major
+	if req.Entity.Id == "" && (req.Entity.Kind == nil || req.Entity.Kind.Major == "") {
+		return nil, fmt.Errorf("either Entity.Id or Entity.Kind.Major is required for filtering entities")
+	}
+
+	// If we have an ID, add it to the filters
+	if req.Entity.Id != "" {
+		log.Printf("Filtering entities by ID: %s", req.Entity.Id)
+	} else {
+		log.Printf("Filtering entities by Kind.Major: %s", req.Entity.Kind.Major)
+	}
 
 	// Use HandleGraphEntityFilter to get filtered entities
 	filteredEntities, err := s.neo4jRepo.HandleGraphEntityFilter(ctx, req)

--- a/design/crud-api/db/repository/neo4j/graph_entity_handler.go
+++ b/design/crud-api/db/repository/neo4j/graph_entity_handler.go
@@ -418,22 +418,28 @@ func (repo *Neo4jRepository) HandleGraphEntityFilter(ctx context.Context, req *p
 	// Extract filters from the request
 	filters := make(map[string]interface{})
 
-	// Add name if present
-	if req.Entity.Name != nil && req.Entity.Name.Value != nil {
-		var stringValue wrapperspb.StringValue
-		if err := req.Entity.Name.Value.UnmarshalTo(&stringValue); err == nil {
-			filters["name"] = stringValue.Value
+	// If ID is present, only use that filter
+	if req.Entity.Id != "" {
+		filters["id"] = req.Entity.Id
+	} else {
+		// Only add other filters if we're not filtering by ID
+		// Add name if present
+		if req.Entity.Name != nil && req.Entity.Name.Value != nil {
+			var stringValue wrapperspb.StringValue
+			if err := req.Entity.Name.Value.UnmarshalTo(&stringValue); err == nil {
+				filters["name"] = stringValue.Value
+			}
 		}
-	}
 
-	// Add created timestamp if present
-	if req.Entity.Created != "" {
-		filters["created"] = req.Entity.Created
-	}
+		// Add created timestamp if present
+		if req.Entity.Created != "" {
+			filters["created"] = req.Entity.Created
+		}
 
-	// Add terminated timestamp if present
-	if req.Entity.Terminated != "" {
-		filters["terminated"] = req.Entity.Terminated
+		// Add terminated timestamp if present
+		if req.Entity.Terminated != "" {
+			filters["terminated"] = req.Entity.Terminated
+		}
 	}
 
 	// Call FilterEntities with the extracted filters

--- a/design/query-api/types.bal
+++ b/design/query-api/types.bal
@@ -4,6 +4,8 @@
 import ballerina/http;
 
 public type entities_search_body record {
+    # Optional entity ID to search for
+    string id?;
     entitiessearch_kind kind?;
     string name?;
     string created?;

--- a/design/tests/e2e/basic_query_tests.py
+++ b/design/tests/e2e/basic_query_tests.py
@@ -625,8 +625,8 @@ def create_government_entities():
     assert res.status_code in [201, 200], f"Failed to create entity: {res.text}"
     print(f"✅ Created {gov_payload['kind']['minor']} entity: {gov_payload['id']}")
 
-def test_search_without_major_kind():
-    """Test that search fails when major kind is not provided."""
+def test_search_without_major_kind_or_id():
+    """Test that search fails when major kind or id is not provided."""
     print("\n🔍 Testing search without major kind...")
     url = f"{QUERY_API_URL}/search"
     payload = {
@@ -950,6 +950,99 @@ def test_search_by_name_kind_and_terminated():
     
     print("✅ Search by name, kind, and termination status successful")
 
+def test_search_by_id():
+    """Test searching entities by ID."""
+    print("\n🔍 Testing search by ID...")
+    url = f"{QUERY_API_URL}/search"
+    payload = {
+        "id": DEPT_ID_1,  # Using the IT Department ID
+        # "kind": {
+        #     "major": ""  # Required field
+        # }
+    }
+    res = requests.post(url, json=payload)
+    assert res.status_code == 200, f"Search failed: {res.text}"
+    
+    body = res.json()
+    assert isinstance(body, dict), "Search response should be a dictionary"
+    assert "body" in body, "Search response should have a 'body' field"
+    assert isinstance(body["body"], list), "Search response body should be a list"
+    assert len(body["body"]) == 1, "Expected exactly one entity in search response"
+    
+    # Debug logging - print the full entity structure
+    print("\nDebug - Full entity structure:", json.dumps(body["body"][0], indent=2))
+    
+    # Verify the returned entity matches the ID
+    entity = body["body"][0]
+    assert entity["id"] == DEPT_ID_1, f"Expected department ID {DEPT_ID_1}, got {entity['id']}"
+    assert entity["kind"]["minor"] == "Department", f"Expected minor kind 'Department', got {entity['kind']['minor']}"
+        
+    # Parse the name JSON string and decode the hex value directly
+    name_obj = json.loads(entity["name"])
+    hex_value = name_obj["value"]
+    decoded_name = bytes.fromhex(hex_value).decode('utf-8')
+    print("Debug - Decoded name:", decoded_name)
+    
+    assert decoded_name == "IT Department", f"Expected name 'IT Department', got {decoded_name}"
+    
+    print("✅ Search by ID successful")
+
+def test_search_by_id_not_found():
+    """Test searching for a non-existent ID."""
+    print("\n🔍 Testing search by non-existent ID...")
+    url = f"{QUERY_API_URL}/search"
+    payload = {
+        "id": "non-existent-id",
+        # "kind": {
+        #     "major": ""  # Required field
+        # }
+    }
+    res = requests.post(url, json=payload)
+    assert res.status_code == 200, f"Search failed: {res.text}"
+    
+    body = res.json()
+    assert isinstance(body, dict), "Search response should be a dictionary"
+    assert "body" in body, "Search response should have a 'body' field"
+    assert isinstance(body["body"], list), "Search response body should be a list"
+    assert len(body["body"]) == 0, "Expected empty list for non-existent ID"
+    
+    print("✅ Search by non-existent ID returned empty results as expected")
+
+def test_search_by_id_with_other_filters():
+    """Test that other filters are ignored when searching by ID."""
+    print("\n🔍 Testing search by ID with additional filters...")
+    url = f"{QUERY_API_URL}/search"
+    payload = {
+        "id": DEPT_ID_1,
+        "kind": {
+            "major": "Organization", 
+            "minor": "Minister"  # This should be ignored since we're searching by ID
+        },
+        "name": "Wrong Name",  # This should be ignored
+        "created": "2023-01-01T00:00:00Z"  # This should be ignored
+    }
+    res = requests.post(url, json=payload)
+    assert res.status_code == 200, f"Search failed: {res.text}"
+    
+    body = res.json()
+    assert isinstance(body, dict), "Search response should be a dictionary"
+    assert "body" in body, "Search response should have a 'body' field"
+    assert isinstance(body["body"], list), "Search response body should be a list"
+    assert len(body["body"]) == 1, "Expected exactly one entity in search response"
+    
+    # Verify the returned entity matches the ID despite other filters
+    entity = body["body"][0]
+    assert entity["id"] == DEPT_ID_1, f"Expected department ID {DEPT_ID_1}, got {entity['id']}"
+    assert entity["kind"]["minor"] == "Department", f"Expected minor kind 'Department', got {entity['kind']['minor']}"
+    
+    # Decode the name value from protobuf Any type
+    name_obj = json.loads(entity["name"])
+    hex_value = name_obj["value"]
+    decoded_name = bytes.fromhex(hex_value).decode('utf-8')
+    assert decoded_name == "IT Department", f"Expected name 'IT Department', got {decoded_name}"
+    
+    print("✅ Search by ID ignored additional filters as expected")
+
 if __name__ == "__main__":
     print("🚀 Running Query API E2E Tests...")
 
@@ -961,15 +1054,19 @@ if __name__ == "__main__":
         test_relationship_query_associated()
         test_relationship_query_linked()
         test_allrelationships_query()
-        # test_entity_search()
         
         # Run government organization search tests
         create_government_entities()
-        test_search_without_major_kind()
+        test_search_without_major_kind_or_id()
         test_search_by_kind_major()
         test_search_by_kind_minor()
         test_search_by_name()
         test_search_by_created_date()
+        
+        # Run ID-based search tests
+        test_search_by_id()
+        test_search_by_id_not_found()
+        test_search_by_id_with_other_filters()
         
         # Run combined filter tests
         test_search_by_name_and_kind()

--- a/design/tests/e2e/basic_query_tests.py
+++ b/design/tests/e2e/basic_query_tests.py
@@ -969,9 +969,6 @@ def test_search_by_id():
     assert isinstance(body["body"], list), "Search response body should be a list"
     assert len(body["body"]) == 1, "Expected exactly one entity in search response"
     
-    # Debug logging - print the full entity structure
-    print("\nDebug - Full entity structure:", json.dumps(body["body"][0], indent=2))
-    
     # Verify the returned entity matches the ID
     entity = body["body"][0]
     assert entity["id"] == DEPT_ID_1, f"Expected department ID {DEPT_ID_1}, got {entity['id']}"
@@ -981,7 +978,6 @@ def test_search_by_id():
     name_obj = json.loads(entity["name"])
     hex_value = name_obj["value"]
     decoded_name = bytes.fromhex(hex_value).decode('utf-8')
-    print("Debug - Decoded name:", decoded_name)
     
     assert decoded_name == "IT Department", f"Expected name 'IT Department', got {decoded_name}"
     


### PR DESCRIPTION
The search endpoint now supports filtering by id. The user must supply either the id or major kind. If the id is present, entities will be filtered only by id. If id is not present, the major kind must be present and the entities will be filtered by the major kind and any other filters passed.

Closes #165 