### PR TITLE
GH-253: [Choreo][Deployment] Deploy CRUD API on Choreo test dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ docker/neo4j/logs/*
 #vscode
 .vscode
 
+#env
+nexoan/crud-api/.env.*
+

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -117,3 +117,10 @@ Entity relFilterName = {
 ```
 
 * Note this doesn't apply to other fields. If you don't want to include a field's value, you don't need to pass the field at all. 
+
+
+## Debug with Choreo
+
+```bash
+choreo connect --project ldf_sandbox_vibhatha --component crud-service
+```

--- a/Dockerfile.crud.choreo
+++ b/Dockerfile.crud.choreo
@@ -1,0 +1,113 @@
+# Dockerfile.crud.choreo
+#
+# Purpose:
+# This Dockerfile builds and runs the CRUD API service, which provides a gRPC interface
+# for creating, reading, updating, and deleting entities in the system. The service
+# connects to both Neo4j (for graph relationships) and MongoDB (for metadata storage).
+#
+# Usage:
+# 1. Build the image:
+#    # For ARM64 (Apple Silicon):
+#    docker build --platform linux/arm64 -t crud-service -f Dockerfile.crud.choreo .
+#    # For AMD64:
+#    docker build --platform linux/amd64 -t crud-service -f Dockerfile.crud.choreo .
+#
+# 2. Run the container (REQUIRED environment variables):
+#   docker run -d \
+#     --name crud-service-choreo \
+#     -p 50051:50051 \
+#     -e NEO4J_URI="neo4j+s://your-neo4j-instance.databases.neo4j.io" \
+#     -e NEO4J_USER="your-neo4j-username" \
+#     -e NEO4J_PASSWORD="your-neo4j-password" \
+#     -e MONGO_URI="mongodb+srv://username:password@your-cluster.mongodb.net/?retryWrites=true&w=majority" \
+#     -e MONGO_DB_NAME="your-mongo-db-name" \
+#     -e MONGO_COLLECTION="your-mongo-collection-name" \
+#     -e MONGO_ADMIN_USER="your-mongo-admin-username" \
+#     -e MONGO_ADMIN_PASSWORD="your-mongo-admin-password" \
+#     -e POSTGRES_PORT=5432 \
+#     -e POSTGRES_USER=postgres \
+#     -e POSTGRES_PASSWORD=postgres \
+#     -e POSTGRES_DB=nexoan \
+#     -e POSTGRES_SSL_MODE=disable \
+#     -e POSTGRES_TEST_DB_URI="" \
+#     -e CRUD_SERVICE_HOST=0.0.0.0 \
+#     -e CRUD_SERVICE_PORT=50051 \
+#     crud-service-choreo
+#
+# Required Environment Variables (must be provided at runtime):
+# - NEO4J_URI: Connection URI for Neo4j database (e.g., neo4j+s://your-instance.databases.neo4j.io)
+# - NEO4J_USER: Username for Neo4j authentication
+# - NEO4J_PASSWORD: Password for Neo4j authentication
+# - MONGO_URI: Connection URI for MongoDB (e.g., mongodb+srv://username:password@your-cluster.mongodb.net/?retryWrites=true&w=majority)
+# - MONGO_DB_NAME: MongoDB database name
+# - MONGO_COLLECTION: MongoDB collection name
+# - MONGO_ADMIN_USER: MongoDB admin username
+# - MONGO_ADMIN_PASSWORD: MongoDB admin password
+# - POSTGRES_PORT: PostgreSQL port (default: 5432)
+# - POSTGRES_USER: PostgreSQL username (default: postgres)
+# - POSTGRES_PASSWORD: PostgreSQL password (default: postgres)
+# - POSTGRES_DB: PostgreSQL database name (default: nexoan)
+# - POSTGRES_SSL_MODE: PostgreSQL SSL mode (default: disable)
+# - POSTGRES_TEST_DB_URI: PostgreSQL test database URI (optional)
+# - CRUD_SERVICE_HOST: Host address to bind the service
+# - CRUD_SERVICE_PORT: Port to expose the gRPC service
+#
+# Note: The service must be run on the ldf-network to communicate with Neo4j and MongoDB services.
+# The hostnames 'neo4j' and 'mongodb' are resolved within the ldf-network.
+
+# Build stage for CRUD service
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.23 AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy the source code
+COPY . .
+
+## Create a new user with UID 10014 and set up directories
+RUN groupadd -g 10014 choreo && \
+    useradd -u 10014 -g choreo -s /bin/bash -m choreouser && \
+    mkdir -p /home/choreouser/.cache/go-build && \
+    chown -R choreouser:choreo /home/choreouser && \
+    chmod -R 755 /home/choreouser
+
+# Download dependencies
+RUN cd nexoan/crud-api && \
+    go mod download
+
+# Build the application
+RUN cd nexoan/crud-api && \
+    go build -o crud-service cmd/server/service.go cmd/server/utils.go
+
+# Final stage
+FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.24
+
+# Install runtime dependencies
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the built binary from builder stage
+COPY --from=builder /app/nexoan/crud-api/crud-service /usr/local/bin/
+COPY --from=builder /app/nexoan/crud-api /app/nexoan/crud-api
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
+# Add log configuration
+ENV LOG_LEVEL=debug
+ENV LOG_FORMAT=text
+
+# Create necessary directories and set permissions
+RUN mkdir -p /home/choreouser/.cache/go-build && \
+    chown -R choreouser:choreo /home/choreouser && \
+    chmod -R 755 /home/choreouser && \
+    chown -R choreouser:choreo /app && \
+    chmod -R 755 /app
+
+USER 10014
+
+# Expose ports
+EXPOSE 50051
+
+# Set the entrypoint to run the service directly
+ENTRYPOINT ["crud-service"] 

--- a/choreo/README.md
+++ b/choreo/README.md
@@ -1,5 +1,74 @@
 # Choreo 
 
+## Local Development and Testing
+
+### Prerequisites
+
+- Docker installed
+- Git repository cloned
+- Ports 50051 (CRUD service) and 8080 (Update service) available
+- MongoDB and Neo4j instances (for CRUD service)
+
+### Environment Setup
+
+Set up your environment variables in your terminal:
+
+```bash
+# MongoDB Configuration
+export MONGO_URI="mongodb+srv://username:password@your-cluster.mongodb.net/?retryWrites=true&w=majority"
+export MONGO_DB_NAME="your-mongo-db-name"
+export MONGO_COLLECTION="your-mongo-collection-name"
+export MONGO_ADMIN_USER="your-mongo-admin-username"
+export MONGO_ADMIN_PASSWORD="your-mongo-admin-password"
+
+# Neo4j Configuration
+export NEO4J_URI="neo4j+s://your-neo4j-instance.databases.neo4j.io"
+export NEO4J_USER="your-neo4j-username"
+export NEO4J_PASSWORD="your-neo4j-password"
+
+# Service Configuration
+export CRUD_SERVICE_HOST="0.0.0.0"
+export CRUD_SERVICE_PORT="50051"
+export UPDATE_SERVICE_HOST="0.0.0.0"
+export UPDATE_SERVICE_PORT="8080"
+export QUERY_SERVICE_HOST="0.0.0.0"
+export QUERY_SERVICE_PORT="8081"
+```
+
+### Running Services Locally
+
+1. Start the CRUD Service:
+```bash
+# Build the CRUD service image
+# For ARM64 (Apple Silicon):
+docker build --platform linux/arm64 -t ldf-choreo-crud-service -f Dockerfile.crud.choreo .
+# For AMD64:
+docker build --platform linux/amd64 -t ldf-choreo-crud-service -f Dockerfile.crud.choreo .
+
+# Run the CRUD service using environment variables
+docker run -d \
+  --name ldf-choreo-crud-service \
+  -p 50051:50051 \
+  -e NEO4J_URI="$NEO4J_URI" \
+  -e NEO4J_USER="$NEO4J_USER" \
+  -e NEO4J_PASSWORD="$NEO4J_PASSWORD" \
+  -e MONGO_URI="$MONGO_URI" \
+  -e MONGO_DB_NAME="$MONGO_DB_NAME" \
+  -e MONGO_COLLECTION="$MONGO_COLLECTION" \
+  -e MONGO_ADMIN_USER="$MONGO_ADMIN_USER" \
+  -e MONGO_ADMIN_PASSWORD="$MONGO_ADMIN_PASSWORD" \
+  -e POSTGRES_HOST="$POSTGRES_HOST" \
+  -e POSTGRES_PORT="$POSTGRES_PORT" \
+  -e POSTGRES_USER="$POSTGRES_USER" \
+  -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+  -e POSTGRES_DB="$POSTGRES_DB" \
+  -e POSTGRES_SSL_MODE="$POSTGRES_SSL_MODE" \
+  -e POSTGRES_TEST_DB_URI="$POSTGRES_TEST_DB_URI" \
+  -e CRUD_SERVICE_HOST="$CRUD_SERVICE_HOST" \
+  -e CRUD_SERVICE_PORT="$CRUD_SERVICE_PORT" \
+  ldf-choreo-crud-service
+```
+
 ## References
 
 1. https://wso2.com/choreo/docs/develop-components/develop-components-with-git/

--- a/nexoan/crud-api/env.choreo.template
+++ b/nexoan/crud-api/env.choreo.template
@@ -1,0 +1,25 @@
+# MongoDB Configuration
+export MONGO_URI="mongodb+srv://your-username:your-password@your-cluster.mongodb.net/?retryWrites=true&w=majority&appName=YourAppName"
+export MONGO_DB_NAME=your_mongo_database_name
+export MONGO_COLLECTION=your_mongo_collection_name
+
+# PostgreSQL Configuration
+export POSTGRES_HOST="your-postgres-host.region.provider.com"
+export POSTGRES_PORT=5432
+export POSTGRES_USER="your_postgres_username"
+export POSTGRES_PASSWORD="your_postgres_password"
+export POSTGRES_DB="your_postgres_database"
+export POSTGRES_SSL_MODE="require"
+# export POSTGRES_TEST_DB_URI="postgresql://username:password@host:port/database?sslmode=require"
+
+# Neo4j Configuration
+export NEO4J_URI=neo4j+s://your-neo4j-instance.databases.neo4j.io
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=your_neo4j_password
+export NEO4J_DATABASE=neo4j
+export AURA_INSTANCEID=your_aura_instance_id
+export AURA_INSTANCENAME=your_aura_instance_name
+
+# CRUD Service Configuration
+export CRUD_SERVICE_HOST=0.0.0.0
+export CRUD_SERVICE_PORT=50051


### PR DESCRIPTION
This PR adds the CRUD service configurations and docker definition for Choreo. 

For the moment we keep two versions of the docker for local development and Choreo. But this could be merged down the road. 

Closes https://github.com/LDFLK/nexoan/issues/253