### PR TITLE
GH-254: [Choreo][Deployment] Deploy Update API on Choreo test dev environment 

### DIFF
--- a/Dockerfile.crud.choreo
+++ b/Dockerfile.crud.choreo
@@ -75,9 +75,9 @@ RUN groupadd -g 10014 choreo && \
 RUN cd nexoan/crud-api && \
     go mod download
 
-# Build the application
+# Build the application as a static binary
 RUN cd nexoan/crud-api && \
-    go build -o crud-service cmd/server/service.go cmd/server/utils.go
+    CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o crud-service cmd/server/service.go cmd/server/utils.go
 
 # Final stage
 FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.24
@@ -87,7 +87,7 @@ RUN apt-get update && \
     apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy the built binary from builder stage
+# Copy the built binary to PATH and the entire crud-api directory
 COPY --from=builder /app/nexoan/crud-api/crud-service /usr/local/bin/
 COPY --from=builder /app/nexoan/crud-api /app/nexoan/crud-api
 COPY --from=builder /etc/passwd /etc/passwd
@@ -109,5 +109,5 @@ USER 10014
 # Expose ports
 EXPOSE 50051
 
-# Set the entrypoint to run the service directly
-ENTRYPOINT ["crud-service"] 
+# Set the entrypoint to run the service from where it actually exists
+ENTRYPOINT ["/app/nexoan/crud-api/crud-service"] 

--- a/Dockerfile.update.choreo
+++ b/Dockerfile.update.choreo
@@ -1,0 +1,205 @@
+# Update Service Dockerfile
+#
+# This Dockerfile builds a Ballerina-based update service that communicates with a CRUD service.
+#
+# Building the Image:
+# -----------------
+# To build the image, run the following command from the directory containing this Dockerfile:
+#   docker build -t ldf-choreo-update-service -f Dockerfile.update.choreo .
+#
+# Running the Container:
+# ---------------------
+# Basic run command:
+#   docker run -p 8080:8080 \
+#     -e CRUD_SERVICE_URL="http://host.docker.internal:50051" \
+#     -e UPDATE_SERVICE_HOST="0.0.0.0" \
+#     -e UPDATE_SERVICE_PORT="8080" \
+#     ldf-choreo-update-service
+#
+# Options:
+#   -p 8080:8080                    : Maps container port 8080 to host port 8080
+#   -e CRUD_SERVICE_URL=<url>       : URL of the CRUD service to connect to (required)
+#   -e UPDATE_SERVICE_HOST=<host>   : Host address to bind the service (default: 0.0.0.0)
+#   -e UPDATE_SERVICE_PORT=<port>   : Port to expose the service (default: 8080)
+#   -d                              : Run in detached mode (background)
+#   --name <container-name>         : Assign a name to the container
+#
+# Examples:
+# 1. Run in detached mode:
+#    docker run -d \
+#      --name ldf-choreo-update-service \
+#      -p 8080:8080 \
+#      -e CRUD_SERVICE_URL="http://host.docker.internal:50051" \
+#      -e UPDATE_SERVICE_HOST="0.0.0.0" \
+#      -e UPDATE_SERVICE_PORT="8080" \
+#      ldf-choreo-update-service
+#
+# 2. Run with custom port mapping:
+#    docker run -p 9090:8080 \
+#      -e CRUD_SERVICE_URL="http://host.docker.internal:50051" \
+#      -e UPDATE_SERVICE_HOST="0.0.0.0" \
+#      -e UPDATE_SERVICE_PORT="8080" \
+#      ldf-choreo-update-service
+#
+# 3. Run with additional JVM options:
+#    docker run -p 8080:8080 \
+#      -e CRUD_SERVICE_URL="http://host.docker.internal:50051" \
+#      -e UPDATE_SERVICE_HOST="0.0.0.0" \
+#      -e UPDATE_SERVICE_PORT="8080" \
+#      -e JAVA_OPTS="-Xmx512m" \
+#      ldf-choreo-update-service
+#
+# 4. Run with container name and restart policy:
+#    docker run -d \
+#      --name ldf-choreo-update-service \
+#      --restart unless-stopped \
+#      -p 8080:8080 \
+#      -e CRUD_SERVICE_URL="http://host.docker.internal:50051" \
+#      -e UPDATE_SERVICE_HOST="0.0.0.0" \
+#      -e UPDATE_SERVICE_PORT="8080" \
+#      ldf-choreo-update-service
+#
+# Environment Variables:
+# ---------------------
+# CRUD_SERVICE_URL: URL of the CRUD service (required)
+#   Format: http://<host>:<port>
+#   Example: http://host.docker.internal:50051
+#
+# UPDATE_SERVICE_HOST: Host address to bind the service
+#   Default: 0.0.0.0
+#   Example: 0.0.0.0
+#
+# UPDATE_SERVICE_PORT: Port to expose the service
+#   Default: 8080
+#   Example: 8080
+#
+# JAVA_OPTS: JVM options (optional)
+#   Example: -Xmx512m -XX:+UseContainerSupport
+#
+# Notes:
+# ------
+# - The service runs on port 8080 inside the container
+# - The container uses a non-root user (choreouser) for security
+# - The service waits for the CRUD service to be available before starting
+# - Use host.docker.internal to connect to services running on the host machine
+# - For macOS, ensure host.docker.internal is properly configured
+#
+# Troubleshooting:
+# ---------------
+# 1. If the service can't connect to the CRUD service:
+#    - Verify the CRUD_SERVICE_URL is correct
+#    - Check if the CRUD service is running and accessible
+#    - Ensure the port mapping is correct
+#    - On macOS, verify host.docker.internal resolution
+#
+# 2. If the service fails to start:
+#    - Check the container logs: docker logs <container-id>
+#    - Verify all required environment variables are set
+#    - Ensure the ports are not already in use
+#    - Check file permissions in the container
+
+# Build stage for Update service
+FROM --platform=linux/amd64 ballerina/ballerina:2201.11.0 AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy the source code
+COPY . .
+
+# Switch to root for package installation and user creation
+USER root
+
+# Install shadow package and create user/group
+RUN apk add --no-cache shadow && \
+    groupadd -g 10014 choreo && \
+    useradd -u 10014 -g choreo -s /bin/bash -m choreouser && \
+    mkdir -p /home/choreouser/.ballerina && \
+    chown -R choreouser:choreo /home/choreouser && \
+    chmod -R 755 /home/choreouser
+
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates netcat-openbsd dos2unix
+
+# Create and set permissions for build directories
+RUN mkdir -p /app/nexoan/update-api/target && \
+    chown -R choreouser:choreo /app && \
+    chmod -R 755 /app
+
+# Switch to non-root user for building
+USER 10014
+
+# Build the application with explicit platform settings
+# ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
+# Build the Ballerina service
+RUN cd nexoan/update-api && \
+    bal build
+
+# Final stage
+FROM --platform=linux/amd64 ballerina/ballerina:2201.11.0
+
+# Switch to root for package installation
+USER root
+
+# Install runtime dependencies and create user
+RUN apk add --no-cache ca-certificates netcat-openbsd dos2unix shadow && \
+    groupadd -g 10014 choreo && \
+    useradd -u 10014 -g choreo -s /bin/bash -m choreouser
+
+# Create necessary directories and set permissions before switching user
+RUN mkdir -p /home/choreouser/.ballerina && \
+    chown -R choreouser:choreo /home/choreouser && \
+    chmod -R 755 /home/choreouser
+
+# Copy the source code and build artifacts
+COPY --from=builder /app/nexoan/update-api /app/nexoan/update-api
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
+# Create startup script with proper line endings
+RUN echo '#!/bin/sh' > /app/start.sh && \
+    echo 'if [ -z "$CRUD_SERVICE_URL" ]; then' >> /app/start.sh && \
+    echo '    echo "Error: CRUD_SERVICE_URL environment variable is not set"' >> /app/start.sh && \
+    echo '    exit 1' >> /app/start.sh && \
+    echo 'fi' >> /app/start.sh && \
+    echo 'if [ -z "$UPDATE_SERVICE_HOST" ]; then' >> /app/start.sh && \
+    echo '    echo "Error: UPDATE_SERVICE_HOST environment variable is not set"' >> /app/start.sh && \
+    echo '    exit 1' >> /app/start.sh && \
+    echo 'fi' >> /app/start.sh && \
+    echo 'if [ -z "$UPDATE_SERVICE_PORT" ]; then' >> /app/start.sh && \
+    echo '    echo "Error: UPDATE_SERVICE_PORT environment variable is not set"' >> /app/start.sh && \
+    echo '    exit 1' >> /app/start.sh && \
+    echo 'fi' >> /app/start.sh && \
+    echo '' >> /app/start.sh && \
+    echo 'echo "Starting update service with CRUD_SERVICE_URL: $CRUD_SERVICE_URL and UPDATE_SERVICE_HOST: $UPDATE_SERVICE_HOST and UPDATE_SERVICE_PORT: $UPDATE_SERVICE_PORT"' >> /app/start.sh && \
+    echo '' >> /app/start.sh && \
+    echo 'exec bal run /app/nexoan/update-api' >> /app/start.sh && \
+    chmod +x /app/start.sh && \
+    dos2unix /app/start.sh
+
+# Set permissions
+RUN chown -R choreouser:choreo /app && \
+    chmod -R 777 /app
+
+# Ensure the entire update-api project directory has write permissions
+RUN chown -R choreouser:choreo /app/nexoan/update-api && \
+    chmod -R 777 /app/nexoan/update-api
+
+# Ensure target directory has proper write permissions
+RUN mkdir -p /app/nexoan/update-api/target && \
+    chown -R choreouser:choreo /app/nexoan/update-api/target && \
+    chmod -R 777 /app/nexoan/update-api/target
+
+# Create necessary directories and set permissions before switching user
+RUN mkdir -p /home/choreouser/.ballerina && \
+    chown -R choreouser:choreo /home/choreouser && \
+    chmod -R 777 /home/choreouser
+
+# Switch to non-root user for running the service
+USER 10014
+
+# Expose ports
+EXPOSE 8080
+
+# Set the entrypoint
+ENTRYPOINT ["/app/start.sh"]

--- a/docker-compose-choreo.yml
+++ b/docker-compose-choreo.yml
@@ -1,16 +1,18 @@
 version: '3.8'
 
+name: ldf-choreo
+
 services:
-  mongodb:
+  mongodb-choreo:
     platform: linux/amd64
     image: mongo:4.4
-    container_name: mongodb
+    container_name: mongodb-choreo
     ports:
-      - "27017:27017"
+      - "27018:27017"  # Different port to avoid conflicts
     volumes:
-      - mongodb_data:/data/db
+      - mongodb_choreo_data:/data/db
     networks:
-      - ldf-network
+      - choreo-network
     environment:
       - MONGO_INITDB_ROOT_USERNAME=admin
       - MONGO_INITDB_ROOT_PASSWORD=admin123
@@ -21,18 +23,18 @@ services:
       retries: 5
       start_period: 30s
 
-  neo4j:
+  neo4j-choreo:
     platform: linux/amd64
     image: neo4j:5.12.0
-    container_name: neo4j
+    container_name: neo4j-choreo
     ports:
-      - "7474:7474"  # HTTP
-      - "7687:7687"  # Bolt
+      - "7475:7474"  # Different port to avoid conflicts
+      - "7688:7687"  # Different port to avoid conflicts
     volumes:
-      - neo4j_data:/data
-      - neo4j_logs:/logs
+      - neo4j_choreo_data:/data
+      - neo4j_choreo_logs:/logs
     networks:
-      - ldf-network
+      - choreo-network
     environment:
       - NEO4J_AUTH=neo4j/neo4j123
       - NEO4J_dbms_memory_pagecache_size=1G
@@ -44,84 +46,85 @@ services:
       timeout: 10s
       retries: 3
 
-  postgres:
+  postgres-choreo:
     platform: linux/amd64
     image: postgres:16
-    container_name: postgres
+    container_name: postgres-choreo
     ports:
-      - "5432:5432"
+      - "5433:5432"  # Different port to avoid conflicts
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_choreo_data:/var/lib/postgresql/data
     networks:
-      - ldf-network
+      - choreo-network
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=nexoan
+      - POSTGRES_DB=ldf_choreo_nexoan
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-  crud:
+  crud-choreo:
     platform: linux/amd64
     build:
       context: .
-      dockerfile: Dockerfile.crud
-      args:
-        - DOCKER_DEFAULT_PLATFORM=linux/amd64
-    container_name: crud
+      dockerfile: Dockerfile.crud.choreo
+    container_name: crud-choreo
     ports:
       - "50051:50051"
     environment:
-      - NEO4J_URI=bolt://neo4j:7687
+      # Neo4j Configuration (using choreo Neo4j)
+      - NEO4J_URI=bolt://neo4j-choreo:7687
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=neo4j123
-      - MONGO_URI=mongodb://admin:admin123@mongodb:27017/admin?authSource=admin
-      - MONGO_DB_NAME=testdb
-      - MONGO_COLLECTION=metadata
+      # MongoDB Configuration (using choreo MongoDB)
+      - MONGO_URI=mongodb://admin:admin123@mongodb-choreo:27017/admin?authSource=admin
+      - MONGO_DB_NAME=ldf_choreo_nexoan
+      - MONGO_COLLECTION=metadata_choreo
       - MONGO_ADMIN_USER=admin
       - MONGO_ADMIN_PASSWORD=admin123
-      - POSTGRES_HOST=postgres
+      # PostgreSQL Configuration (using choreo PostgreSQL)
+      - POSTGRES_HOST=postgres-choreo
       - POSTGRES_PORT=5432
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=nexoan
+      - POSTGRES_DB=ldf_choreo_nexoan
       - POSTGRES_SSL_MODE=disable
+      - POSTGRES_TEST_DB_URI=postgresql://neondb_owner:npg_OFnZiXT01BEc@ep-green-feather-a1z2cn5i-pooler.ap-southeast-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require
+      # CRUD Service Configuration
       - CRUD_SERVICE_HOST=0.0.0.0
       - CRUD_SERVICE_PORT=50051
     depends_on:
-      mongodb:
+      mongodb-choreo:
         condition: service_healthy
-      neo4j:
+      neo4j-choreo:
         condition: service_healthy
-      postgres:
+      postgres-choreo:
         condition: service_healthy
-    networks:
-      - ldf-network
     healthcheck:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:50051 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
+    networks:
+      - choreo-network
 
-  update:
+  update-choreo:
     platform: linux/amd64
     build:
       context: .
-      dockerfile: Dockerfile.update
-    container_name: update
+      dockerfile: Dockerfile.update.choreo
+    container_name: update-choreo
     ports:
       - "8080:8080"
-    networks:
-      - ldf-network
     environment:
-      - CRUD_SERVICE_URL=http://crud:50051
+      - CRUD_SERVICE_URL=http://crud-choreo:50051
       - UPDATE_SERVICE_HOST=0.0.0.0
       - UPDATE_SERVICE_PORT=8080
     depends_on:
-      crud:
+      crud-choreo:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "8080"]
@@ -129,64 +132,37 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
-
-  query:
-    platform: linux/amd64
-    build:
-      context: .
-      dockerfile: Dockerfile.query
-    container_name: query
-    ports:
-      - "8081:8081"
     networks:
-      - ldf-network
-    environment:
-      - CRUD_SERVICE_URL=http://crud:50051
-      - QUERY_SERVICE_HOST=0.0.0.0
-      - QUERY_SERVICE_PORT=8081
-    depends_on:
-      crud:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "8081"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
+      - choreo-network
 
-  e2e:
+  e2e-choreo:
     platform: linux/amd64
     image: python:3.9-slim
-    container_name: e2e
+    container_name: e2e-choreo
     volumes:
       - ./nexoan/tests/e2e:/app/tests
     working_dir: /app/tests
     networks:
-      - ldf-network
+      - choreo-network
     environment:
       - PYTHONUNBUFFERED=1
-      - UPDATE_SERVICE_URL=http://update:8080
-      - QUERY_SERVICE_URL=http://query:8081
+      - UPDATE_SERVICE_URL=http://update-choreo:8080
     depends_on:
-      update:
-        condition: service_healthy
-      query:
+      update-choreo:
         condition: service_healthy
     command: >
       sh -c "
         echo 'Waiting for services to be ready...' &&
         sleep 10 &&
         pip install requests &&
-        python3 basic_crud_tests.py &&
-        python3 basic_query_tests.py"
+        python3 basic_crud_tests.py"
 
 networks:
-  ldf-network:
+  choreo-network:
     driver: bridge
 
 volumes:
-  mongodb_data:
-  neo4j_data:
-  neo4j_logs:
-  postgres_data: 
-
+  mongodb_choreo_data:
+  neo4j_choreo_data:
+  neo4j_choreo_logs:
+  postgres_choreo_data: 

--- a/nexoan/tests/e2e/basic_crud_tests.py
+++ b/nexoan/tests/e2e/basic_crud_tests.py
@@ -16,20 +16,20 @@ Running the tests:
 ## Run CRUD Server
 
 ```bash
-cd design/crud-api
+cd nexoan/crud-api
 ./crud-server
 ```
 ## Run API Server
 
 ```bash
-cd design/api
+cd nexoan/update-api
 bal run
 ```
 
 ## Run Tests
 
 ```bash
-cd design/tests/e2e
+cd nexoan/tests/e2e
 python3 basic_crud_tests.py
 ```
 
@@ -65,10 +65,11 @@ class CrudTestUtils:
 
 class TestCRUDAPI(unittest.TestCase):
     def setUp(self):
-        update_host = os.getenv('UPDATE_SERVICE_HOST', 'localhost')
-        update_port = os.getenv('UPDATE_SERVICE_PORT', '8080')
-        self.base_url = f"http://{update_host}:{update_port}/entities"
-        
+        print("🟢 Setting up test environment...")
+        update_service_url = os.getenv('UPDATE_SERVICE_URL', f"http://0.0.0.0:8080")
+        print("🟢 UPDATE_SERVICE_URL: ", update_service_url)
+        self.base_url = f"{update_service_url}/entities"
+        print("🟢 BASE_URL: ", self.base_url)
 
 class BasicCRUDTests:
 
@@ -392,9 +393,10 @@ class GraphEntityTests(BasicCRUDTests):
 
 
 def get_base_url():
-    update_host = os.getenv('UPDATE_SERVICE_HOST', 'localhost')
-    update_port = os.getenv('UPDATE_SERVICE_PORT', '8080')
-    return f"http://{update_host}:{update_port}/entities"
+    print("🟢 Setting up test environment...")
+    update_service_url = os.getenv('UPDATE_SERVICE_URL', f"http://0.0.0.0:8080")
+    print("🟢 UPDATE_SERVICE_URL: ", update_service_url)
+    return f"{update_service_url}/entities"
 
 if __name__ == "__main__":
     print("🚀 Running End-to-End API Test Suite...")

--- a/nexoan/update-api/env.template
+++ b/nexoan/update-api/env.template
@@ -1,0 +1,10 @@
+# config format 1 (default for development)
+export CRUD_SERVICE_HOST=0.0.0.0
+export CRUD_SERVICE_PORT=50051
+export UPDATE_SERVICE_HOST=0.0.0.0
+export UPDATE_SERVICE_PORT=8080
+
+# config format 2 (default for deployment)
+
+export CRUD_SERVICE_URL=http://0.0.0.0:50051
+export UPDATE_SERVICE_URL=http://0.0.0.0:8080

--- a/nexoan/update-api/tests/service_test.bal
+++ b/nexoan/update-api/tests/service_test.bal
@@ -5,13 +5,13 @@ import ballerina/http;
 import ballerina/os;
 
 // Get environment variables without fallback values
-string testCrudHostname = os:getEnv("CRUD_SERVICE_HOST");
-string testCrudPort = os:getEnv("CRUD_SERVICE_PORT");
 string testUpdateHostname = os:getEnv("UPDATE_SERVICE_HOST");
 string testUpdatePort = os:getEnv("UPDATE_SERVICE_PORT");
 
+// Try to get complete CRUD service URL from environment variable first
+string? crudServiceUrlEnv = os:getEnv("CRUD_SERVICE_URL");
+string testCrudServiceUrl = crudServiceUrlEnv ?: "http://0.0.0.0:50051";
 // Construct URLs using string concatenation
-string testCrudServiceUrl = "http://" + testCrudHostname + ":" + testCrudPort;
 string testUpdateServiceUrl = "http://" + testUpdateHostname + ":" + testUpdatePort;
 
 // Before Suite Function


### PR DESCRIPTION
This PR adds the new docker configs to run the Update service in Choreo and make necessary changes to the existing settings. 

The idea is to run the Update service as a Ballerina component within Choreo. So we have changed the way we take the environmental variables by adopting `configurable` strings Ballerina to help with that. Choreo clearly identifies these language features and makes it easy to adopt. 

Closes https://github.com/LDFLK/nexoan/issues/254